### PR TITLE
test: implementa repositório em memória e teste de caso de uso para deletar reservas

### DIFF
--- a/backend/src/repositories/inMemory/InMemoryReservaRepository.ts
+++ b/backend/src/repositories/inMemory/InMemoryReservaRepository.ts
@@ -1,0 +1,15 @@
+import type { ReservaRepository } from '../ReservaRepository'
+import type { Reserva } from '../../entities/Reserva'
+
+export class InMemoryReservaRepository implements ReservaRepository {
+	public reservas: Reserva[] = []
+	async create(reserva: Reserva): Promise<void> {
+		this.reservas.push(reserva)
+	}
+	async findByMesaId(mesaId: number): Promise<Reserva | null> {
+		return this.reservas.find((reserva) => reserva.mesaId === mesaId) || null
+	}
+	async delete(mesaId: number): Promise<void> {
+		this.reservas = this.reservas.filter((reserva) => reserva.mesaId !== mesaId)
+	}
+}

--- a/backend/src/useCases/DeletarReservaUseCase.test.ts
+++ b/backend/src/useCases/DeletarReservaUseCase.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { DeletarReservaUseCase } from './DeletarReservaUseCase'
+import { InMemoryReservaRepository } from '../repositories/inMemory/InMemoryReservaRepository'
+import { CriarReservaUseCase } from './CriarReservaUseCase'
+
+describe('DeletarReservaUseCase', async () => {
+	let inMemoryReservaRepository: InMemoryReservaRepository
+	let criarReservaUseCase: CriarReservaUseCase
+	let systemUnderTest: DeletarReservaUseCase
+
+	beforeEach(() => {
+		inMemoryReservaRepository = new InMemoryReservaRepository()
+		criarReservaUseCase = new CriarReservaUseCase(inMemoryReservaRepository)
+		systemUnderTest = new DeletarReservaUseCase(inMemoryReservaRepository)
+	})
+	it('deve ser possível deletar uma reserva', async () => {
+		const mesaId = 2
+		await criarReservaUseCase.execute({
+			mesaId,
+			data: new Date().toISOString().split('T')[0],
+			hora: '12:00',
+			nomeResponsavel: 'João',
+			quantidadePessoas: 4,
+		})
+		await systemUnderTest.execute({
+			mesaId,
+		})
+		expect(inMemoryReservaRepository.reservas).toHaveLength(0)
+		expect(await inMemoryReservaRepository.findByMesaId(mesaId)).toBeNull()
+	})
+	it('não deve ser possível deletar uma reserva que não existe', async () => {
+		const mesaId = 3
+		await expect(() =>
+			systemUnderTest.execute({
+				mesaId,
+			}),
+		).rejects.toThrow()
+	})
+	it('não deve ser possível deletar uma reserva com mesaId inválido', async () => {
+		const mesaId = -1
+		await expect(() =>
+			systemUnderTest.execute({
+				mesaId,
+			}),
+		).rejects.toThrow()
+	})
+	it('não deve ser possível deletar uma reserva com mesaId não numérico', async () => {
+		const mesaId = 'abc' as unknown as number
+		await expect(() =>
+			systemUnderTest.execute({
+				mesaId,
+			}),
+		).rejects.toThrow()
+	})
+	it('não deve ser possível deletar uma reserva com mesaId não informado', async () => {
+		await expect(() =>
+			systemUnderTest.execute({
+				mesaId: undefined as unknown as number,
+			}),
+		).rejects.toThrow()
+	})
+})


### PR DESCRIPTION
## Resumo por Sourcery

Disponibiliza um repositório de reservas em memória e adiciona um caso de teste para garantir que o caso de uso de exclusão de reserva se comporta corretamente

Melhorias:
- Implementa InMemoryReservaRepository para suportar operações de create, findByMesaId e delete em memória

Testes:
- Adiciona teste unitário para DeletarReservaUseCase para validar a exclusão de reserva

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide an in-memory reservation repository and add a test case to ensure the delete reservation use case behaves correctly

Enhancements:
- Implement InMemoryReservaRepository to support create, findByMesaId, and delete operations in memory

Tests:
- Add unit test for DeletarReservaUseCase to validate reservation deletion

</details>